### PR TITLE
Remove dependency on debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 var genericPool = require('generic-pool')
 var util = require('util')
 var EventEmitter = require('events').EventEmitter
-var debug = require('debug')
 var objectAssign = require('object-assign')
 
 var Pool = module.exports = function (options, Client) {
   EventEmitter.call(this)
   this.options = objectAssign({}, options)
-  this.log = this.options.log || debug('pg:pool')
+  this.log = this.options.log || function () { }
   this.Client = this.options.Client || Client || require('pg').Client
   this.Promise = this.options.Promise || Promise
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "standard-format": "2.2.1"
   },
   "dependencies": {
-    "debug": "^2.2.0",
     "generic-pool": "2.4.2",
     "object-assign": "4.1.0"
   }

--- a/test/logging.js
+++ b/test/logging.js
@@ -1,0 +1,20 @@
+var expect = require('expect.js')
+var co = require('co')
+
+var describe = require('mocha').describe
+var it = require('mocha').it
+
+var Pool = require('../')
+
+describe('logging', function () {
+  it('logs to supplied log function if given', co.wrap(function * () {
+    var messages = []
+    var log = function (msg) {
+      messages.push(msg)
+    }
+    var pool = new Pool({ log: log })
+    yield pool.query('SELECT NOW()')
+    expect(messages.length).to.be.greaterThan(0)
+    return pool.end()
+  }))
+})


### PR DESCRIPTION
Accept a `log: (message, other...) => { }` parameter as a config option, but by default use a no-op function instead of debug.