### PR TITLE
Add 'connect' event to pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var Pool = module.exports = function (options, Client) {
   this.options.create = this.options.create || this._create.bind(this)
   this.options.destroy = this.options.destroy || this._destroy.bind(this)
   this.pool = new genericPool.Pool(this.options)
+  this.onCreate = this.options.onCreate
 }
 
 util.inherits(Pool, EventEmitter)
@@ -38,6 +39,7 @@ Pool.prototype._create = function (cb) {
 
   client.connect(function (err) {
     this.log('client connected')
+    this.emit('connect')
     if (err) {
       this.log('client connection error:', err)
       cb(err)

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ Pool.prototype._create = function (cb) {
 
   client.connect(function (err) {
     this.log('client connected')
-    this.emit('connect')
+    this.emit('connect', client)
     if (err) {
       this.log('client connection error:', err)
       cb(err)

--- a/test/events.js
+++ b/test/events.js
@@ -1,0 +1,24 @@
+var expect = require('expect.js')
+
+var describe = require('mocha').describe
+var it = require('mocha').it
+
+var Pool = require('../')
+
+describe('events', function () {
+  it('emits connect before callback', function (done) {
+    var pool = new Pool()
+    var connectCalled = false
+    pool.on('connect', function () {
+      connectCalled = true
+    })
+
+    pool.connect(function (err, client, release) {
+      if (err) return done(err)
+      release()
+      pool.end()
+      expect(connectCalled).to.be.ok()
+      done()
+    })
+  })
+})

--- a/test/events.js
+++ b/test/events.js
@@ -8,16 +8,16 @@ var Pool = require('../')
 describe('events', function () {
   it('emits connect before callback', function (done) {
     var pool = new Pool()
-    var connectCalled = false
-    pool.on('connect', function () {
-      connectCalled = true
+    var emittedClient = false
+    pool.on('connect', function (client) {
+      emittedClient = client
     })
 
     pool.connect(function (err, client, release) {
       if (err) return done(err)
       release()
       pool.end()
-      expect(connectCalled).to.be.ok()
+      expect(client).to.be(emittedClient)
       done()
     })
   })


### PR DESCRIPTION
Connect event fired whenever a new client is connected.

Example:

```js
var pool = new Pool()

pool.on('connect', client => {
  console.log('new client created')
})

pool.query('SELECT $1::text as name', ['foo'])
  .then(res => console.log(res.rows[0].name))
```

The output of this program is

```
new client created
foo
```