### PR TITLE
Url parsing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ var PgNativeClient = require('pg-native')
 var pgNativePool = new Pool({ Client: PgNativeClient })
 ```
 
+##### Note:
+The Pool constructor does not support passing Database URL as the parameter. To use pool on heroku, for example, you need to parse the URL into a config object. Here is an example of how to parse a Database URL.
+
+```js
+const pg = require('pg');
+const url = require('url')
+
+const params = url.parse(process.env.DATABASE_URL);
+const auth = params.auth.split(':');
+
+const config = {
+  user: auth[0],
+  password: auth[1],
+  host: params.hostname,
+  port: params.port,
+  database: params.pathname.split('/')[1],
+  ssl: true
+};
+
+/* Transforms, 'progres://DBusersecret@DBHost:#####/myDB', into
+config = {
+  user: 'DBuser',
+  password: 'secret',
+  host: 'DBHost',
+  port: '#####',
+  database: 'myDB',
+  ssl: true
+} */
+``` 
+
 ### acquire clients with a promise
 
 pg-pool supports a fully promise-based api for acquiring clients

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ var pgNativePool = new Pool({ Client: PgNativeClient })
 ```
 
 ##### Note:
-The Pool constructor does not support passing Database URL as the parameter. To use pool on heroku, for example, you need to parse the URL into a config object. Here is an example of how to parse a Database URL.
+The Pool constructor does not support passing a Database URL as the parameter. To use pg-pool on heroku, for example, you need to parse the URL into a config object. Here is an example of how to parse a Database URL.
 
 ```js
-const pg = require('pg');
+const Pool = require('pg-pool');
 const url = require('url')
 
 const params = url.parse(process.env.DATABASE_URL);
@@ -65,15 +65,19 @@ const config = {
   ssl: true
 };
 
-/* Transforms, 'progres://DBusersecret@DBHost:#####/myDB', into
-config = {
-  user: 'DBuser',
-  password: 'secret',
-  host: 'DBHost',
-  port: '#####',
-  database: 'myDB',
-  ssl: true
-} */
+const pool = Pool(config);
+
+/*
+  Transforms, 'progres://DBusersecret@DBHost:#####/myDB', into
+  config = {
+    user: 'DBuser',
+    password: 'secret',
+    host: 'DBHost',
+    port: '#####',
+    database: 'myDB',
+    ssl: true
+  }
+*/
 ``` 
 
 ### acquire clients with a promise

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const config = {
 const pool = Pool(config);
 
 /*
-  Transforms, 'progres://DBusersecret@DBHost:#####/myDB', into
+  Transforms, 'progres://DBuser:secret@DBHost:#####/myDB', into
   config = {
     user: 'DBuser',
     password: 'secret',


### PR DESCRIPTION
I was struggling to get pg-pool working on Heroku, and after a couple of hours I stumbled upon this PR: https://github.com/brianc/node-pg-pool/pull/5, and realized that the Pool constructor could not accept a DatabaseURL string.

I saw that you were considering adding an example of parsing a DatabaseURL to the readme. I thought I would go ahead and put in a PR in case anyone else runs into the same problem.

Let me know if I should change anything or if you do not think it is worth an example in the readme. Thanks for your contributions, I like these pg modules a lot!

Also, here's a screenshot in case you want a visual preview:

<img width="965" alt="screen shot 2016-07-18 at 3 11 59 pm" src="https://cloud.githubusercontent.com/assets/14980932/16927342/d1aa4456-4cfa-11e6-9fcf-c8a29f2be1f9.png">
