### PR TITLE
Bug fix: Pool.query now calls cb if connect() fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,12 @@ Pool.prototype.query = function (text, values, cb) {
 
   return new this.Promise(function (resolve, reject) {
     this.connect(function (err, client, done) {
-      if (err) return reject(err)
+      if (err) {
+        if (cb) {
+          cb(err)
+        }
+        return reject(err)
+      }
       client.query(text, values, function (err, res) {
         done(err)
         err ? reject(err) : resolve(res)

--- a/test/index.js
+++ b/test/index.js
@@ -61,14 +61,14 @@ describe('pool', function () {
         })
       })
     })
-    
+
     it('passes connection errors to callback', function (done) {
       var pool = new Pool({host: 'no-postgres-server-here.com'})
       pool.query('SELECT $1::text as name', ['brianc'], function (err, res) {
-        expect(res).to.be(undefined);
-        expect(err).to.be.an(Error);
+        expect(res).to.be(undefined)
+        expect(err).to.be.an(Error)
         pool.end(function (err) {
-          done(err);
+          done(err)
         })
       })
     })

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,17 @@ describe('pool', function () {
         })
       })
     })
+    
+    it('passes connection errors to callback', function (done) {
+      var pool = new Pool({host: 'no-postgres-server-here.com'})
+      pool.query('SELECT $1::text as name', ['brianc'], function (err, res) {
+        expect(res).to.be(undefined);
+        expect(err).to.be.an(Error);
+        pool.end(function (err) {
+          done(err);
+        })
+      })
+    })
 
     it('removes client if it errors in background', function (done) {
       var pool = new Pool()


### PR DESCRIPTION
Old behavior was that if connect called back with an error, the promise would get rejected but the cb function would never get called.