### PR TITLE
Add Flow Type definition.

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,112 @@
+/* @flow
+**/
+
+var EventEmitter = require('events').EventEmitter;
+const pg = require('pg');
+const Client = pg.Client;
+import type {
+  ResultSet,
+  QueryConfig,
+  QueryCallback,
+  QueryType,
+  PG_ERROR,
+} from 'pg';
+
+/*
+ * PgPoolConfig's properties are passed unchanged to both
+ * the node-postgres Client constructor and the node-pool constructor
+ * allowing you to fully configure the behavior of both
+ * node-pool (https://github.com/coopernurse/node-pool)
+*/
+type PgPoolConfig = {
+  // node-pool ----------------
+  name: string,
+  create: Function,
+  destroy: Function,
+  max: number,
+  min: number,
+  refreshIdle: boolean,
+  idleTimeoutMillis: number,
+  reapIntervalMillis: number,
+  returnToHead: boolean,
+  priorityRange: number,
+  validate: Function,
+  validateAsync: Function,
+  log: Function,
+
+  // node-postgres Client ------
+  //database user's name
+  user: string,
+  //name of database to connect
+  database: string,
+  //database user's password
+  password: string,
+  //database port
+  port: number,
+  // database host. defaults to localhost
+  host: string,
+  // whether to try SSL/TLS to connect to server. default value: false
+  ssl: boolean,
+  // name displayed in the pg_stat_activity view and included in CSV log entries
+  // default value: process.env.PGAPPNAME
+  application_name: string,
+  // fallback value for the application_name configuration parameter
+  // default value: false
+  fallback_application_name: string,
+
+  // pg-pool
+  Client: any,
+  Promise: any,
+  onCreate: Function,
+};
+type PoolConnectCallback = (error: PG_ERROR|null, client: Client|null, done: DoneCallback) => void;
+type DoneCallback = (error?: mixed) => void;
+
+/*
+ * Not extends from Client, cause some of Client's functions(ex: connect and end)
+ * should not be used by PoolClient (which returned from Pool.connect).
+*/
+type PoolClient = {
+  release(error?: mixed): void,
+
+  query:
+  ( (query: QueryConfig|string, callback?: QueryCallback) => QueryType ) &
+  ( (text: string, values: Array<any>, callback?: QueryCallback) => QueryType ),
+
+  on:
+  ((event: 'drain', listener: () => void) => events$EventEmitter )&
+  ((event: 'error', listener: (err: PG_ERROR) => void) => events$EventEmitter )&
+  ((event: 'notification', listener: (message: any) => void) => events$EventEmitter )&
+  ((event: 'notice', listener: (message: any) => void) => events$EventEmitter )&
+  ((event: 'end', listener: () => void) => events$EventEmitter ),
+}
+
+// https://github.com/facebook/flow/blob/master/lib/node.js#L581
+// on() returns a events$EventEmitter
+declare class Pool extends events$EventEmitter {
+  constructor(options: $Shape<PgPoolConfig>, Client?: Class<Client>): void;
+  connect(cb?: PoolConnectCallback): Promise<PoolClient>;
+  take(cb?: PoolConnectCallback): Promise<PoolClient>;
+  end(cb?: DoneCallback): Promise<void>;
+
+// Note: not like the pg's Client, the Pool.query return a Promise,
+// not a Thenable Query which Client returned.
+  query:
+  ( (query: QueryConfig|string, callback?: QueryCallback) => Promise<ResultSet> ) &
+  ( (text: string, values: Array<any>, callback?: QueryCallback) => Promise<ResultSet>);
+
+  on:
+  ((event: 'connect', listener: (client: PoolClient) => void) => events$EventEmitter )&
+  ((event: 'acquire', listener: (client: PoolClient) => void) => events$EventEmitter )&
+  ((event: "error", listener: (err: PG_ERROR) => void) => events$EventEmitter )&
+  ((event: string, listener: Function) => events$EventEmitter );
+}
+
+module.exports = Pool;
+
+export type {
+  PgPoolConfig,
+  PoolConnectCallback,
+  DoneCallback,
+  PoolClient
+};

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "expect.js": "0.3.1",
     "lodash": "4.13.1",
     "mocha": "^2.3.3",
-    "pg": "5.1.0",
     "standard": "7.1.2",
     "standard-format": "2.2.1"
   },
   "dependencies": {
+    "pg": "5.1.0",
     "generic-pool": "2.4.2",
     "object-assign": "4.1.0"
   }


### PR DESCRIPTION
Using .js.flow.
Flow will auto pickup `.js.flow` as a type def, when it appear in packages.

Move `pg` from devDependencies to dependencies, because the type def file will import type from `pg`.(reused some types defined in pg)

This is cooperated with [`node-postgres PR#1120`](https://github.com/brianc/node-postgres/pull/1120) type def.

---

I am new to `Postgresql` and `pg`. So maybe there are some misunderstanding in my type def.
In this type def, i hide those function be used  internally.
And only exposed the public API.(Did i miss some API?)
