### PR TITLE
Bump generic-pool dep to 2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "standard-format": "2.2.1"
   },
   "dependencies": {
-    "generic-pool": "2.4.2",
+    "generic-pool": "2.4.3",
     "object-assign": "4.1.0"
   }
 }


### PR DESCRIPTION
This isn't super necessary since you're handling domain binding properly anyway, but coopernurse/node-pool#152 made generic-pool play a little nicer with them automatically.