### PR TITLE
Add connectionSetup as configuration option to prepare a client

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,12 @@ Pool.prototype._create = function (cb) {
     } else {
       this.log('client connected')
       this.emit('connect', client)
-      cb(null, client)
+
+      if (this.options.connectionSetup && typeof this.options.connectionSetup == 'function') {
+        this.options.connectionSetup(client, cb)
+      } else {
+        cb(null, client)
+      }
     }
   }.bind(this))
 }


### PR DESCRIPTION
I propose to add an option 'connectionSetup' to make it possible to do setup before a client is used. My own use-case is to set the search path to a certain schema. 

This relates to an open issue at node-postgres about the same use case: https://github.com/brianc/node-postgres/issues/1123