### PR TITLE
Promise pg pool connect (v1.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const pool = new Pool(config);
     ssl: true
   }
 */
-``` 
+```
 
 ### acquire clients with a promise
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,11 @@ Pool.prototype._create = function (cb) {
         this.log('came back from connect')
         cb(null, client)
       })
-      .catch(err => cb(err, null))
+      .catch(err => {
+        this.log('connect listener error:', err)
+        this.pool.destroy(client)
+        cb(err, null)
+      })
   }.bind(this))
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var genericPool = require('generic-pool')
 var util = require('util')
 var objectAssign = require('object-assign')
-var EventEmitter = require('promise-events');
+var EventEmitter = require('promise-events')
 
 // there is a bug in the generic pool where it will not recreate
 // destroyed workers (even if there is waiting work to do) unless
@@ -97,17 +97,16 @@ Pool.prototype._create = function (cb) {
     if (err) {
       this.log('client connection error:', err)
       cb(err, null)
-      return;
+      return
     }
 
     this.log('client connected')
-    this.emit('connect',  client)
-      .then(()=>{
-          this.log('came back from connect')
-          cb(null, client)
+    this.emit('connect', client)
+      .then(() => {
+        this.log('came back from connect')
+        cb(null, client)
       })
       .catch(err => cb(err, null))
-
   }.bind(this))
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var genericPool = require('generic-pool')
 var util = require('util')
-var EventEmitter = require('events').EventEmitter
 var objectAssign = require('object-assign')
+var EventEmitter = require('promise-events');
 
 // there is a bug in the generic pool where it will not recreate
 // destroyed workers (even if there is waiting work to do) unless
@@ -27,7 +27,7 @@ var Pool = module.exports = function (options, Client) {
   if (!(this instanceof Pool)) {
     return new Pool(options, Client)
   }
-  EventEmitter.call(this)
+
   this.options = objectAssign({}, options)
   this.log = this.options.log || function () { }
   this.Client = this.options.Client || Client || require('pg').Client
@@ -97,11 +97,17 @@ Pool.prototype._create = function (cb) {
     if (err) {
       this.log('client connection error:', err)
       cb(err, null)
-    } else {
-      this.log('client connected')
-      this.emit('connect', client)
-      cb(null, client)
+      return;
     }
+
+    this.log('client connected')
+    this.emit('connect',  client)
+      .then(()=>{
+          this.log('came back from connect')
+          cb(null, client)
+      })
+      .catch(err => cb(err, null))
+
   }.bind(this))
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "generic-pool": "2.4.3",
-    "object-assign": "4.1.0"
+    "object-assign": "4.1.0",
+    "promise-events": "^0.1.3"
   }
 }

--- a/test/events.js
+++ b/test/events.js
@@ -26,7 +26,9 @@ describe('events', function () {
     var pool = new Pool()
     var emittedClient = false
     pool.on('connect', function (client) {
-      return client.query('SELECT now()')
+      return new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
       .then(() => {
         emittedClient = client
       })
@@ -41,21 +43,17 @@ describe('events', function () {
     })
   })
 
-  it('catch error on connect', function (done) {
+  it('catch error on connect listener', function (done) {
     var pool = new Pool()
-    var connectingErr = 'connecting error'
+    var listenerErr = 'Listener error'
     pool.on('connect', function (client) {
-      return client.query('SELECT now()')
-      .then(() => {
-        throw new Error(connectingErr)
-      })
+      throw new Error(listenerErr)
     })
 
     pool.connect(function (err, client, release) {
       if (!err) return done('did not catch the error')
-      release()
       pool.end()
-      expect(err.message).to.equal(connectingErr)
+      expect(err.message).to.equal(listenerErr)
       done()
     })
   })

--- a/test/events.js
+++ b/test/events.js
@@ -22,6 +22,44 @@ describe('events', function () {
     })
   })
 
+  it('waits on connect until finished', function (done) {
+    var pool = new Pool()
+    var emittedClient = false
+    pool.on('connect', function (client) {
+      return client.query('SELECT now()')
+      .then(() => {
+        emittedClient = client
+      })
+    })
+
+    pool.connect(function (err, client, release) {
+      if (err) return done(err)
+      release()
+      pool.end()
+      expect(client).to.be(emittedClient)
+      done()
+    })
+  })
+
+  it.only('catch error on connect', function (done) {
+    var pool = new Pool()
+    var connectingErr = 'connecting error'
+    pool.on('connect', function (client) {
+      return client.query('SELECT now()')
+      .then(() => {
+        throw new Error(connectingErr)
+      })
+    })
+
+    pool.connect(function (err, client, release) {
+      if (!err) return done('did not catch the error')
+      release()
+      pool.end()
+      expect(err.message).to.equal(connectingErr)
+      done()
+    })
+  })
+
   it('emits "connect" only with a successful connection', function (done) {
     var pool = new Pool({
       // This client will always fail to connect

--- a/test/events.js
+++ b/test/events.js
@@ -41,7 +41,7 @@ describe('events', function () {
     })
   })
 
-  it.only('catch error on connect', function (done) {
+  it('catch error on connect', function (done) {
     var pool = new Pool()
     var connectingErr = 'connecting error'
     pool.on('connect', function (client) {


### PR DESCRIPTION
Hello :)
This pr is branched from version v1.8.0, it introduces promised connect.
According to documentation (https://node-postgres.com/api/pool) the pool 'onConnect' event is the place to run setup commands on a client. Unfortunately the _create function who's emitting the connect event does not wait on the connect to finish its work, which makes it impossible to run set up functionality like setting query group on the client or any async functionality for that matter.
The new code implements 'promise-events'  as the EventEmitter. It inherits Node's built-in EventEmitter interface, except that selected methods are overridden to return a promise.
(https://www.npmjs.com/package/promise-events)
I've also added tests to check that we wait on the connect, plus catching an error if there is one.
If you approve the change is it possible to create v1.8.1 for the fix?
Tnx!
Hadas.