### PR TITLE
idleListener no longer grabs references to things it doesn't need

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,20 @@ function promisify (Promise, callback) {
   return { callback: cb, result: result }
 }
 
+function makeIdleListener (pool, client) {
+  return function idleListener (err) {
+    err.client = client
+    client.removeListener('error', idleListener)
+    client.on('error', () => {
+      pool.log('additional client error after disconnection due to error', err)
+    })
+    pool._remove(client)
+    // TODO - document that once the pool emits an error
+    // the client has already been closed & purged and is unusable
+    pool.emit('error', err, client)
+  }
+}
+
 class Pool extends EventEmitter {
   constructor (options, Client) {
     super()
@@ -184,17 +198,7 @@ class Pool extends EventEmitter {
 
     const client = new this.Client(this.options)
     this._clients.push(client)
-    const idleListener = (err) => {
-      err.client = client
-      client.removeListener('error', idleListener)
-      client.on('error', () => {
-        this.log('additional client error after disconnection due to error', err)
-      })
-      this._remove(client)
-      // TODO - document that once the pool emits an error
-      // the client has already been closed & purged and is unusable
-      this.emit('error', err, client)
-    }
+    const idleListener = makeIdleListener(this, client)
 
     this.log('checking client timeout')
 


### PR DESCRIPTION
Hello!  I'm one of the maintainers of New Relic's Node.js agent, and I ran into an issue with our promise instrumentation using async_hooks along with this library.  The promise instrumentation has to wait for some promises to be garbage collected before it can clear them as finished and drop the context it is holding onto for that promise.  The issue we were observing was the idleListener closure was holding onto a reference to the callback passed into connect, which was holding onto a reference to a promise.  This change only passes in the necessary data into the idleListener.