### PR TITLE
Typo in "Connection terminated" error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ class Pool extends EventEmitter {
         // remove the dead client from our list of clients
         this._clients = this._clients.filter(c => c !== client)
         if (timeoutHit) {
-          err.message = 'Connection terminiated due to connection timeout'
+          err.message = 'Connection terminated due to timeout'
         }
         cb(err, undefined, NOOP)
       } else {


### PR DESCRIPTION
Was spelled '**terminiated**' 