### PR TITLE
Fix _endCallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,7 @@ class Pool extends EventEmitter {
         this.log('client failed to connect', err)
         // remove the dead client from our list of clients
         this._clients = this._clients.filter(c => c !== client)
+        if (!this._clients.length && this._endCallback) this._endCallback()
         if (timeoutHit) {
           err.message = 'Connection terminated due to connection timeout'
         }


### PR DESCRIPTION
If `Pool#end` happens between client initiate connection and receiving callback with error, `_endCallback` will be never called.