### PR TITLE
Max checkout timeout event

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ var pool2 = new Pool({
   min: 4, // set min pool size to 4
   idleTimeoutMillis: 1000, // close idle clients after 1 second
   connectionTimeoutMillis: 1000, // return an error after 1 second if connection could not be established
+  maxCheckoutMillis: 1000 // receive a maxCheckoutExceeded event after 1 second
 })
 
 //you can supply a custom client constructor
@@ -79,7 +80,7 @@ const pool = new Pool(config);
     ssl: true
   }
 */
-``` 
+```
 
 ### acquire clients with a promise
 
@@ -293,6 +294,30 @@ setTimeout(function () {
   console.log('connect count:', connectCount) // output: connect count: 10
   console.log('acquire count:', acquireCount) // output: acquire count: 200
 }, 100)
+
+```
+
+#### maxCheckoutExceeded
+
+Fired whenever a client is checked out longer then  `maxCheckoutMillis`
+
+Example:
+
+This allows you to count the number of clients which have exceeded the checkout timeout.
+
+```js
+var Pool = require('pg-pool')
+var pool = new Pool({ maxCheckoutMillis : 1000 })
+
+let checkoutExceededCount = 0
+
+pool.on('maxCheckoutExceeded', function (client) {
+  checkoutExceededCount++;
+})
+
+setTimeout(function () {
+  console.log('checkout exceeded count:', checkoutExceededCount) // output: checkout exceeded count: 1
+}, 1500)
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,8 @@ class Pool extends EventEmitter {
       const client = idleItem.client
       client.release = release.bind(this, client)
       this.emit('acquire', client)
-      return waiter.callback(undefined, client, client.release)
+
+      return this._callCallback(client, waiter.callback)
     }
     if (!this._isFull()) {
       return this.newClient(waiter)
@@ -146,6 +147,20 @@ class Pool extends EventEmitter {
     this._clients = this._clients.filter(c => c !== client)
     client.end()
     this.emit('remove', client)
+  }
+
+  _callCallback (client, callback) {
+    if (!this.options.maxCheckoutMillis) {
+      return callback(undefined, client, client.release)
+    }
+
+    const tid = setTimeout(() => {
+      this.emit('maxCheckoutExceeded', client)
+    }, this.options.maxCheckoutMillis)
+    return callback(undefined, client, (err) => {
+      clearTimeout(tid)
+      client.release(err)
+    })
   }
 
   connect (cb) {
@@ -250,9 +265,11 @@ class Pool extends EventEmitter {
         this.emit('acquire', client)
         if (!pendingItem.timedOut) {
           if (this.options.verify) {
-            this.options.verify(client, pendingItem.callback)
+            this._callCallback(client, (_, client) => {
+              this.options.verify(client, pendingItem.callback)
+            })
           } else {
-            pendingItem.callback(undefined, client, client.release)
+            this._callCallback(client, pendingItem.callback)
           }
         } else {
           if (this.options.verify) {


### PR DESCRIPTION
Based on https://github.com/brianc/node-pg-pool/pull/109

Adds a new force unlock timeout, which is by default disabled to stay backwards compatible.

This timeout forcefully ends the client if a client was taken from the pool longer then `forceUnlockTimeoutMillis` and the main use-case for this is preventing any kind of pool client leaks, which could render a pool consumers completely unusable.

WIP but happy about comments, will add tests as soon as possible.