### PR TITLE
Prevent double release with callback

### DIFF
--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -43,6 +43,20 @@ describe('pool error handling', function () {
       expect(() => client.release()).to.throwError()
       return yield pool.end()
     }))
+
+    it('should throw each time with callbacks', function (done) {
+      const pool = new Pool()
+
+      pool.connect(function (err, client, clientDone) {
+        expect(err).not.to.be.an(Error)
+        clientDone()
+
+        expect(() => clientDone()).to.throwError()
+        expect(() => clientDone()).to.throwError()
+
+        pool.end(done)
+      })
+    })
   })
 
   describe('calling connect after end', () => {


### PR DESCRIPTION
When using the `done` callback instead of `client.release`, double releasing a client was possible causing clients to be re-added multiple times.

Ensure that the release method itself can't be called twice instead of patching on the client.

I also did a small refactoring to ensure that new client and re-used client acquiring goes through the same code path and moved release into the client instead of using bind. Happy to remove this, but I found the logic a bit more readable afterwards.