### PR TITLE
fix for cases where connection is broken and release() is called, avo…

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function release (client, err) {
   }
 
   if (this._clients.indexOf(client) > -1) {
-  this._idle.push(new IdleItem(client, tid))
+    this._idle.push(new IdleItem(client, tid))
   }
   this._pulseQueue()
 }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ function release (client, err) {
     }, this.options.idleTimeoutMillis)
   }
 
+  if (this._clients.indexOf(client) > -1) {
   this._idle.push(new IdleItem(client, tid))
+  }
   this._pulseQueue()
 }
 


### PR DESCRIPTION
Fixing a case when release() is called for a broken connection. without this, the broken connection is returned to the idle pool and reused.