### PR TITLE
Minor cleanup - inline throwOnRelease()

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,6 @@ class PendingItem {
   }
 }
 
-function throwOnRelease () {
-  throw new Error('Release called on client which has already been released to the pool.')
-}
-
 function promisify (Promise, callback) {
   if (callback) {
     return { callback: callback, result: undefined }
@@ -248,7 +244,7 @@ class Pool extends EventEmitter {
 
     client.release = (err) => {
       if (released) {
-        throwOnRelease()
+        throw new Error('Release called on client which has already been released to the pool.')
       }
 
       released = true


### PR DESCRIPTION
The throwOnRelease() function does not appear to be exposed anywhere,
and it does not appear to make any sense to have it as a standalone func,
as it ovecomplicates things and makes function call as non-returning.  Inlined it.