### PR TITLE
Handle client errors in pool.query

### DIFF
--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -226,4 +226,19 @@ describe('pool error handling', function () {
       })
     })
   })
+
+  it('handles post-checkout client failures in pool.query', (done) => {
+    const pool = new Pool({ max: 1 })
+    pool.on('error', () => {
+      // We double close the connection in this test, prevent exception caused by that
+    })
+    pool.query('SELECT pg_sleep(5)', [], (err) => {
+      expect(err).to.be.an(Error)
+      done()
+    })
+
+    setTimeout(() => {
+      pool._clients[0].end()
+    }, 1000)
+  })
 })


### PR DESCRIPTION
If an error not related to the query occurs, the client is emitting an error event.

Forward this event to the callback.

Fixes https://github.com/brianc/node-pg-pool/pull/123#issuecomment-531603798